### PR TITLE
Update Niivue and refactor mesh saving

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-import { Niivue } from '@niivue/niivue';
-import { createMZ3, downloadMesh } from './marching-cubes.js';
+import { Niivue, NVMeshUtilities } from '@niivue/niivue';
+import { createMZ3 } from './marching-cubes.js';
 
 // Dynamically load the worker module
 async function createWorker() {
@@ -37,15 +37,19 @@ async function main() {
     if (nv1.meshes.length < 1) {
       return;
     }
+    let format = 'obj'
+    let isCompressed = false;
     if (formatSelect.selectedIndex == 0) {
-      downloadMesh(nv1.meshes[0].pts, nv1.meshes[0].tris, 'simplified_mesh.mz3', true);
+      format = 'mz3';
+      isCompressed = true;
     }
     if (formatSelect.selectedIndex == 1) {
-      downloadMesh(nv1.meshes[0].pts, nv1.meshes[0].tris, 'simplified_mesh.obj');
+      format = 'obj';
     }
     if (formatSelect.selectedIndex == 2) {
-      downloadMesh(nv1.meshes[0].pts, nv1.meshes[0].tris, 'simplified_mesh.stl');
+      format = 'stl';
     }
+    NVMeshUtilities.saveMesh(nv1.meshes[0].pts, nv1.meshes[0].tris, `simplified_mesh.${format}`, isCompressed);
   };
 
   remeshBtn.onclick = function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "niivue-brainchop",
       "version": "0.1.0",
       "dependencies": {
-        "@niivue/niivue": "^0.43.6",
+        "@niivue/niivue": "^0.44.1",
         "jslint": "^0.12.1"
       },
       "devDependencies": {
@@ -403,10 +403,9 @@
       }
     },
     "node_modules/@niivue/niivue": {
-      "version": "0.43.6",
-      "resolved": "https://registry.npmjs.org/@niivue/niivue/-/niivue-0.43.6.tgz",
-      "integrity": "sha512-mN+R+CcHSB20MkjPMwK9rvX+f5B8gJaDqcnyZzO0AhYJYjVxq44HYFvsKEqNANfuVtdUVZOHor2wWuhBjQ+FFg==",
-      "license": "BSD-2-Clause",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@niivue/niivue/-/niivue-0.44.1.tgz",
+      "integrity": "sha512-cJ3x6h9p3q7glMruit7M6KqFt0DPDI6+w4WeGh59Ly+jbW2EcBpe6JfRAKR8CcsxB21ePakGYRydPBRtGVEAug==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",
         "@ungap/structured-clone": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "niivue-brainchop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "niivue-brainchop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@niivue/niivue": "^0.44.1",
         "jslint": "^0.12.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "niivue-brainchop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@niivue/niivue": "^0.43.6",
+    "@niivue/niivue": "^0.44.1",
     "jslint": "^0.12.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates niivue to the most recent version at time of writing. Be sure to run `npm run install` after merging and pulling. 

The mesh saving has also been refactored to use the utility functions now distributed with Niivue. 